### PR TITLE
Makefile to automate the env setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.DEFAULT_GOAL := help
+
+help:          ## Show available options with this Makefile
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+.PHONY : run
+run:           ## Update the submodule and build neo-local with smart contracts
+run:
+	@echo "**** Intializing submodules and compiling smart contracts locally ****"
+	@git submodule update --init && \
+	cd neo-local && \
+	cp ../contracts/*.py ./smart-contracts && \
+	make

--- a/README.md
+++ b/README.md
@@ -2,16 +2,12 @@
 
 An environment for nOS development.
 
-**TODO:** Make the following all automatic 🤖:
-
 For now, manually start the `neo-local` environment and load contracts:
 
 ```sh
-git submodule update --init
-cd neo-local
-cp ../contracts/*.py ./smart-contracts
-
-make
+$ git clone https://github.com/nos/nos-local.git
+$ cd nos-local
+$ make run
 ```
 
 Once you're at the `neo-python` prompt (wallet password is "coz"):


### PR DESCRIPTION
Added `Makefile` to automate the steps which were currently being manually executed to launch the local-net.

Executing `make` on the root level of project creates:
```
➯ ➯ ➯ make
help:           Show available options with this Makefile
run:            Update the submodule and build neo-local with smart contracts```

